### PR TITLE
[cli] Require instance name when emitting browser links

### DIFF
--- a/pkg/bazelclient/commands/build/BUILD.bazel
+++ b/pkg/bazelclient/commands/build/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "build",
@@ -56,5 +56,15 @@ go_library(
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//semaphore",
         "@org_golang_x_term//:term",
+    ],
+)
+
+go_test(
+    name = "build_test",
+    srcs = ["do_build_test.go"],
+    embed = [":build"],
+    deps = [
+        "//pkg/bazelclient/arguments",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/bazelclient/commands/build/do_build.go
+++ b/pkg/bazelclient/commands/build/do_build.go
@@ -95,6 +95,13 @@ func newGRPCClient(endpoint string, commonFlags *arguments.CommonFlags) (*grpc.C
 	return grpc.NewClient(target, grpc.WithTransportCredentials(clientCredentials))
 }
 
+func validateBuildCommonFlags(commonFlags *arguments.CommonFlags) error {
+	if commonFlags.BrowserUrl != "" && commonFlags.RemoteInstanceName == "" {
+		return errors.New("--browser_url requires --remote_instance_name to be non-empty, because browser links include the instance name in their URL path")
+	}
+	return nil
+}
+
 type localCapturableDirectoryOptions[TFile model_core.ReferenceMetadata] struct {
 	fileParameters *model_filesystem.FileCreationParameters
 	capturer       model_filesystem.FileMerkleTreeCapturer[TFile]
@@ -166,6 +173,9 @@ func (f *localCapturableFile[TFile]) Discard() {
 func DoBuild(args *arguments.BuildCommand, workspacePath path.Parser) {
 	logger := logging.NewLoggerFromFlags(&args.CommonFlags)
 	commands.ValidateInsideWorkspace(logger, "build", workspacePath)
+	if err := validateBuildCommonFlags(&args.CommonFlags); err != nil {
+		logger.Fatal(formatted.Text(err.Error()))
+	}
 
 	remoteCacheClient, err := newGRPCClient(args.CommonFlags.RemoteCache, &args.CommonFlags)
 	if err != nil {

--- a/pkg/bazelclient/commands/build/do_build_test.go
+++ b/pkg/bazelclient/commands/build/do_build_test.go
@@ -1,0 +1,32 @@
+package build
+
+import (
+	"testing"
+
+	"bonanza.build/pkg/bazelclient/arguments"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateBuildCommonFlags(t *testing.T) {
+	t.Run("NoBrowserURLAndEmptyInstanceName", func(t *testing.T) {
+		require.NoError(t, validateBuildCommonFlags(&arguments.CommonFlags{}))
+	})
+
+	t.Run("BrowserURLAndNonEmptyInstanceName", func(t *testing.T) {
+		require.NoError(t, validateBuildCommonFlags(&arguments.CommonFlags{
+			BrowserUrl:         "http://localhost:9982/",
+			RemoteInstanceName: "bonanza-demo",
+		}))
+	})
+
+	t.Run("BrowserURLAndEmptyInstanceName", func(t *testing.T) {
+		require.EqualError(
+			t,
+			validateBuildCommonFlags(&arguments.CommonFlags{
+				BrowserUrl: "http://localhost:9982/",
+			}),
+			"--browser_url requires --remote_instance_name to be non-empty, because browser links include the instance name in their URL path",
+		)
+	})
+}


### PR DESCRIPTION
Addresses #15.
Follow-up on https://github.com/buildbarn/bonanza/pull/26

`bonanza_bazel` currently accepts `--browser_url` with an empty
`--remote_instance_name`, but generated browser links include the instance name
as a URL path segment. With the empty default, that segment is dropped and the
links no longer match bonanza_browser routes.

This PR adds an early build-command guard requiring a non-empty `--remote_instance_name` whenever `--browser_url` is set. 

**Validation:**
- `bazel test --test_output=errors //pkg/bazelclient/commands/build:all`
- `bazel test --test_output=errors //cmd/bonanza_browser:all //pkg/bazelclient/arguments:all //pkg/storage/object:all`
- (also `bazel test --test_output=errors //...`)