### PR TITLE
Properly deal with the instance name being empty

### DIFF
--- a/cmd/bonanza_browser/browser_service.go
+++ b/cmd/bonanza_browser/browser_service.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"net/url"
 	"path"
 	"slices"
 	"strconv"
@@ -154,6 +153,9 @@ func renderPage(title string, body []g.Node) g.Node {
 func getReferenceFromRequest(r *http.Request) (model_core.Decodable[object.GlobalReference], error) {
 	var bad model_core.Decodable[object.GlobalReference]
 	instanceNameStr := r.PathValue("instance_name")
+	if instanceNameStr == "-" {
+		instanceNameStr = ""
+	}
 	instanceName, err := object.NewInstanceName(instanceNameStr)
 	if err != nil {
 		return bad, util.StatusWrapf(err, "Invalid instance name %#v", instanceNameStr)
@@ -648,7 +650,7 @@ func (s *BrowserService) doEvaluation(w http.ResponseWriter, r *http.Request) (g
 	jsonRenderer := messageJSONRenderer{
 		basePath: path.Join(
 			strings.Repeat("../", len(parentKeyReferences))+"../../../../object",
-			url.PathEscape(evaluationsListReference.Value.InstanceName.String()),
+			evaluationsListReference.Value.InstanceName.AsURLSafeComponent(),
 			referenceFormat.ToProto().String(),
 		),
 		referenceFormat: &referenceFormat,
@@ -1576,7 +1578,7 @@ func (s *BrowserService) doOperation(w http.ResponseWriter, r *http.Request) (g.
 			}
 			jsonRenderer.basePath = path.Join(
 				"../../object",
-				namespace.InstanceName.String(),
+				namespace.InstanceName.AsURLSafeComponent(),
 				namespace.ReferenceFormat.ToProto().String(),
 			)
 			jsonRenderer.fallbackObjectFormat = executeWithStorageAction.ActionFormat

--- a/cmd/bonanza_browser/browser_service.go
+++ b/cmd/bonanza_browser/browser_service.go
@@ -153,6 +153,12 @@ func renderPage(title string, body []g.Node) g.Node {
 // an object.GlobalReference that can be used to download an object.
 func getReferenceFromRequest(r *http.Request) (model_core.Decodable[object.GlobalReference], error) {
 	var bad model_core.Decodable[object.GlobalReference]
+	instanceNameStr := r.PathValue("instance_name")
+	instanceName, err := object.NewInstanceName(instanceNameStr)
+	if err != nil {
+		return bad, util.StatusWrapf(err, "Invalid instance name %#v", instanceNameStr)
+	}
+
 	referenceFormatStr := r.PathValue("reference_format")
 	referenceFormatValue, ok := object_pb.ReferenceFormat_Value_value[referenceFormatStr]
 	if !ok {
@@ -173,7 +179,7 @@ func getReferenceFromRequest(r *http.Request) (model_core.Decodable[object.Globa
 
 	return model_core.CopyDecodable(
 		localReference,
-		object.NewInstanceName(r.PathValue("instance_name")).WithLocalReference(localReference.Value),
+		instanceName.WithLocalReference(localReference.Value),
 	), nil
 }
 

--- a/pkg/bazelclient/commands/build/do_build.go
+++ b/pkg/bazelclient/commands/build/do_build.go
@@ -575,7 +575,10 @@ func DoBuild(args *arguments.BuildCommand, workspacePath path.Parser) {
 	}
 
 	logger.Info(formatted.Text("Uploading module sources"))
-	instanceName := object.NewInstanceName(args.CommonFlags.RemoteInstanceName)
+	instanceName, err := object.NewInstanceName(args.CommonFlags.RemoteInstanceName)
+	if err != nil {
+		logger.Fatal(formatted.Textf("Invalid --remote_instance_name=%#v: %s", args.CommonFlags.RemoteInstanceName, err))
+	}
 	actionReference := createdAction.Value.GetLocalReference()
 	actionGlobalReference := instanceName.WithLocalReference(actionReference)
 	dagUploader := dag_grpc.NewUploader(

--- a/pkg/bazelclient/commands/build/do_build.go
+++ b/pkg/bazelclient/commands/build/do_build.go
@@ -656,7 +656,7 @@ func DoBuild(args *arguments.BuildCommand, workspacePath path.Parser) {
 			append(
 				[]string{
 					"object",
-					url.PathEscape(instanceName.String()),
+					instanceName.AsURLSafeComponent(),
 					referenceFormat.ToProto().String(),
 					actionReferenceStr,
 				},
@@ -687,7 +687,7 @@ func DoBuild(args *arguments.BuildCommand, workspacePath path.Parser) {
 		if baseURL, err := url.JoinPath(
 			browserURL,
 			"object",
-			url.PathEscape(instanceName.String()),
+			instanceName.AsURLSafeComponent(),
 			referenceFormat.ToProto().String(),
 		); err == nil {
 			jsonFormatter.baseURL = baseURL
@@ -834,7 +834,7 @@ func DoBuild(args *arguments.BuildCommand, workspacePath path.Parser) {
 			if evaluationURL, err := url.JoinPath(
 				browserURL,
 				"evaluation",
-				url.PathEscape(namespace.InstanceName.String()),
+				namespace.InstanceName.AsURLSafeComponent(),
 				namespace.ReferenceFormat.ToProto().String(),
 				model_core.DecodableLocalReferenceToString(*outcomesReference),
 				base64.RawURLEncoding.EncodeToString(marshaledBuildResultKey),
@@ -865,7 +865,7 @@ func formatKey(namespace object.Namespace, keyAny model_core.Message[*model_core
 				if evaluationURL, err := url.JoinPath(
 					browserURL,
 					"evaluation",
-					url.PathEscape(namespace.InstanceName.String()),
+					namespace.InstanceName.AsURLSafeComponent(),
 					namespace.ReferenceFormat.ToProto().String(),
 					model_core.DecodableLocalReferenceToString(*outcomesReference),
 					base64.RawURLEncoding.EncodeToString(marshaledKey),

--- a/pkg/proto/storage/object/object.proto
+++ b/pkg/proto/storage/object/object.proto
@@ -95,8 +95,11 @@ message Namespace {
   // The instance of the execution system to operate against. A server
   // may support multiple instances of the execution system (with their
   // own workers, storage, caches, etc.). The server MAY require use of
-  // this field to select between them in an implementation- defined
+  // this field to select between them in an implementation-defined
   // fashion, otherwise it can be omitted.
+  //
+  // Implementations MAY place restrictions on the format of the
+  // instance name string (e.g., requiring them to be path-like).
   string instance_name = 1;
 
   // The format that is used to encode references.

--- a/pkg/storage/dag/BUILD.bazel
+++ b/pkg/storage/dag/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "//pkg/storage/object",
         "//pkg/storage/tag",
         "@com_github_buildbarn_bb_storage//pkg/testutil",
+        "@com_github_buildbarn_bb_storage//pkg/util",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",  # keep

--- a/pkg/storage/dag/uploader_server_test.go
+++ b/pkg/storage/dag/uploader_server_test.go
@@ -14,6 +14,7 @@ import (
 	"bonanza.build/pkg/storage/tag"
 
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"golang.org/x/sync/semaphore"
@@ -466,7 +467,7 @@ func TestUploaderServer(t *testing.T) {
 			tagUpdater.EXPECT().UpdateTag(
 				gomock.Any(),
 				object.Namespace{
-					InstanceName:    object.NewInstanceName("hello/world"),
+					InstanceName:    util.Must(object.NewInstanceName("hello/world")),
 					ReferenceFormat: object.SHA256V1ReferenceFormat,
 				},
 				tag.Key{
@@ -631,7 +632,7 @@ func TestUploaderServer(t *testing.T) {
 			tagUpdater.EXPECT().UpdateTag(
 				gomock.Any(),
 				object.Namespace{
-					InstanceName:    object.NewInstanceName("hello/world"),
+					InstanceName:    util.Must(object.NewInstanceName("hello/world")),
 					ReferenceFormat: object.SHA256V1ReferenceFormat,
 				},
 				tag.Key{

--- a/pkg/storage/object/BUILD.bazel
+++ b/pkg/storage/object/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     name = "object_test",
     srcs = [
         "downloader_server_test.go",
+        "instance_name_test.go",
         "local_reference_test.go",
         "mocks_object_test.go",
         "uploader_server_test.go",

--- a/pkg/storage/object/global_reference.go
+++ b/pkg/storage/object/global_reference.go
@@ -2,6 +2,8 @@ package object
 
 import (
 	"strings"
+
+	"github.com/buildbarn/bb-storage/pkg/util"
 )
 
 // GlobalReference uniquely identifies an object across all namespaces.
@@ -15,7 +17,7 @@ type GlobalReference struct {
 // tests.
 func MustNewSHA256V1GlobalReference(instanceName, hash string, sizeBytes uint32, height uint8, degree uint16, maximumTotalParentsSizeBytes uint64) GlobalReference {
 	return GlobalReference{
-		InstanceName:   NewInstanceName(instanceName),
+		InstanceName:   util.Must(NewInstanceName(instanceName)),
 		LocalReference: MustNewSHA256V1LocalReference(hash, sizeBytes, height, degree, maximumTotalParentsSizeBytes),
 	}
 }

--- a/pkg/storage/object/grpc/BUILD.bazel
+++ b/pkg/storage/object/grpc/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//pkg/proto/storage/object",
         "//pkg/storage/object",
         "@com_github_buildbarn_bb_storage//pkg/testutil",
+        "@com_github_buildbarn_bb_storage//pkg/util",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",  # keep
         "@org_golang_google_grpc//codes",

--- a/pkg/storage/object/grpc/uploader_test.go
+++ b/pkg/storage/object/grpc/uploader_test.go
@@ -9,6 +9,7 @@ import (
 	"bonanza.build/pkg/storage/object/grpc"
 
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -78,7 +79,7 @@ func TestUploader(t *testing.T) {
 		)
 		_, err := uploader.UploadObject(
 			ctx,
-			object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+			util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 			contents,
 			[][]byte{
 				{1, 2, 3},
@@ -160,7 +161,7 @@ func TestUploader(t *testing.T) {
 		)
 		_, err := uploader.UploadObject(
 			ctx,
-			object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+			util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 			contents,
 			/* outgoingReferencesLeases = */ nil,
 			/* wantContentsIfIncomplete = */ false,

--- a/pkg/storage/object/instance_name.go
+++ b/pkg/storage/object/instance_name.go
@@ -1,5 +1,12 @@
 package object
 
+import (
+	"regexp"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
 // InstanceName denotes the name of a namespace in storage.
 //
 // In this implementation instance names can have arbitrary string
@@ -9,9 +16,21 @@ type InstanceName struct {
 	value string
 }
 
+const validInstanceNameComponentPattern = `[0-9A-Za-z]+`
+
+// Be conservative about what what kinds of instance names we accept.
+// It's often desirable to embed instance names in pathnames and URLs.
+var (
+	validInstanceNameRegexp       = regexp.MustCompile(`^(` + validInstanceNameComponentPattern + `(/` + validInstanceNameComponentPattern + `)*)?$`)
+	errInvalidInstanceNamePattern = status.Error(codes.InvalidArgument, "Instance name must consist of zero or more components matching "+validInstanceNameComponentPattern+" separated by a forward slash")
+)
+
 // NewInstanceName creates a new InstanceName that corresponds to the
 // provided value.
 func NewInstanceName(value string) (InstanceName, error) {
+	if !validInstanceNameRegexp.MatchString(value) {
+		return InstanceName{}, errInvalidInstanceNamePattern
+	}
 	return InstanceName{
 		value: value,
 	}, nil

--- a/pkg/storage/object/instance_name.go
+++ b/pkg/storage/object/instance_name.go
@@ -11,10 +11,10 @@ type InstanceName struct {
 
 // NewInstanceName creates a new InstanceName that corresponds to the
 // provided value.
-func NewInstanceName(value string) InstanceName {
+func NewInstanceName(value string) (InstanceName, error) {
 	return InstanceName{
 		value: value,
-	}
+	}, nil
 }
 
 // WithLocalReference upgrades a LocalReference to a GlobalReference

--- a/pkg/storage/object/instance_name.go
+++ b/pkg/storage/object/instance_name.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"net/url"
 	"regexp"
 
 	"google.golang.org/grpc/codes"
@@ -58,4 +59,14 @@ func (in InstanceName) WithReferenceFormat(referenceFormat ReferenceFormat) Name
 
 func (in InstanceName) String() string {
 	return in.value
+}
+
+// AsURLSafeComponent escapes the instance name string, so that it can
+// safely be embedded into URLs. All slashes are are converted to %2F.
+// If the instance name is empty, special value "-" is returned.
+func (in InstanceName) AsURLSafeComponent() string {
+	if in.value == "" {
+		return "-"
+	}
+	return url.PathEscape(in.value)
 }

--- a/pkg/storage/object/instance_name_test.go
+++ b/pkg/storage/object/instance_name_test.go
@@ -1,0 +1,60 @@
+package object_test
+
+import (
+	"testing"
+
+	"bonanza.build/pkg/storage/object"
+
+	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/stretchr/testify/require"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestInstanceName(t *testing.T) {
+	t.Run("Invalid", func(t *testing.T) {
+		for _, str := range []string{
+			// Forbid redundant slashes.
+			"/",
+			"/hello",
+			"hello/",
+			"hello//world",
+
+			// Don't allow special characters for the time being.
+			"_hello",
+			"hello-",
+
+			// Don't permit any whitespace characters, as
+			// those tend to cause problems in many
+			// contexts.
+			"no spaces allowed",
+			"no\ttabs\tallowed",
+
+			// Reserve "-" and "_" components as special
+			// values for either denoting the absence of an
+			// instance name, or to terminate them. This can
+			// be used by tools like bonanza_browser to
+			// embed instance names into URLs.
+			"-",
+			"_",
+		} {
+			_, err := object.NewInstanceName(str)
+			testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Instance name must consist of zero or more components matching [0-9A-Za-z]+ separated by a forward slash"), err)
+		}
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		for _, str := range []string{
+			"",
+			"hello",
+			"hello123",
+			"123hello",
+			"MyTeam/Project42",
+		} {
+			instanceName, err := object.NewInstanceName(str)
+			require.NoError(t, err)
+			require.Equal(t, str, instanceName.String())
+		}
+	})
+}

--- a/pkg/storage/object/instance_name_test.go
+++ b/pkg/storage/object/instance_name_test.go
@@ -45,16 +45,17 @@ func TestInstanceName(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		for _, str := range []string{
-			"",
-			"hello",
-			"hello123",
-			"123hello",
-			"MyTeam/Project42",
+		for str, urlComponent := range map[string]string{
+			"":                 "-",
+			"hello":            "hello",
+			"hello123":         "hello123",
+			"123hello":         "123hello",
+			"MyTeam/Project42": "MyTeam%2FProject42",
 		} {
 			instanceName, err := object.NewInstanceName(str)
 			require.NoError(t, err)
 			require.Equal(t, str, instanceName.String())
+			require.Equal(t, urlComponent, instanceName.AsURLSafeComponent())
 		}
 	})
 }

--- a/pkg/storage/object/leaserenewing/BUILD.bazel
+++ b/pkg/storage/object/leaserenewing/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//pkg/proto/storage/object",
         "//pkg/storage/object",
         "@com_github_buildbarn_bb_storage//pkg/testutil",
+        "@com_github_buildbarn_bb_storage//pkg/util",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",

--- a/pkg/storage/object/leaserenewing/uploader_test.go
+++ b/pkg/storage/object/leaserenewing/uploader_test.go
@@ -9,6 +9,7 @@ import (
 	"bonanza.build/pkg/storage/object/leaserenewing"
 
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"golang.org/x/sync/semaphore"
@@ -170,7 +171,7 @@ func TestUploader(t *testing.T) {
 			gomock.InOrder(
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					/* childrenLeases = */ nil,
 					/* wantContentsIfIncomplete = */ true,
@@ -205,7 +206,7 @@ func TestUploader(t *testing.T) {
 				}, nil),
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					[]any{
 						nil,
@@ -226,7 +227,7 @@ func TestUploader(t *testing.T) {
 			}()
 			result, err := uploader.UploadObject(
 				ctx,
-				object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+				util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 				/* contents = */ nil,
 				/* childrenLeases = */ nil,
 				/* wantContentsIfIncomplete = */ false,
@@ -272,7 +273,7 @@ func TestUploader(t *testing.T) {
 			gomock.InOrder(
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					/* childrenLeases = */ nil,
 					/* wantContentsIfIncomplete = */ true,
@@ -291,7 +292,7 @@ func TestUploader(t *testing.T) {
 				}, nil),
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					[]any{"Lease"},
 					/* wantContentsIfIncomplete = */ false,
@@ -305,7 +306,7 @@ func TestUploader(t *testing.T) {
 			}()
 			_, err := uploader.UploadObject(
 				ctx,
-				object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+				util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 				/* contents = */ nil,
 				/* childrenLeases = */ nil,
 				/* wantContentsIfIncomplete = */ false,
@@ -334,7 +335,7 @@ func TestUploader(t *testing.T) {
 			gomock.InOrder(
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					/* childrenLeases = */ nil,
 					/* wantContentsIfIncomplete = */ true,
@@ -353,7 +354,7 @@ func TestUploader(t *testing.T) {
 				}, nil),
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					[]any{"Lease"},
 					/* wantContentsIfIncomplete = */ false,
@@ -370,7 +371,7 @@ func TestUploader(t *testing.T) {
 			}()
 			_, err := uploader.UploadObject(
 				ctx,
-				object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+				util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 				/* contents = */ nil,
 				/* childrenLeases = */ nil,
 				/* wantContentsIfIncomplete = */ false,
@@ -394,7 +395,7 @@ func TestUploader(t *testing.T) {
 			gomock.InOrder(
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					/* childrenLeases = */ nil,
 					/* wantContentsIfIncomplete = */ true,
@@ -413,7 +414,7 @@ func TestUploader(t *testing.T) {
 				}, nil),
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					[]any{"Lease"},
 					/* wantContentsIfIncomplete = */ false,
@@ -427,7 +428,7 @@ func TestUploader(t *testing.T) {
 			}()
 			_, err := uploader.UploadObject(
 				ctx,
-				object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+				util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 				/* contents = */ nil,
 				/* childrenLeases = */ nil,
 				/* wantContentsIfIncomplete = */ false,
@@ -457,7 +458,7 @@ func TestUploader(t *testing.T) {
 			gomock.InOrder(
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					/* childrenLeases = */ nil,
 					/* wantContentsIfIncomplete = */ true,
@@ -483,7 +484,7 @@ func TestUploader(t *testing.T) {
 				).Return(object.UploadObjectMissing[any]{}, nil),
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					[]any{
 						"Lease",
@@ -502,7 +503,7 @@ func TestUploader(t *testing.T) {
 			}()
 			result, err := uploader.UploadObject(
 				ctx,
-				object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+				util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 				/* contents = */ nil,
 				/* childrenLeases = */ nil,
 				/* wantContentsIfIncomplete = */ true,
@@ -531,7 +532,7 @@ func TestUploader(t *testing.T) {
 			gomock.InOrder(
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					/* childrenLeases = */ nil,
 					/* wantContentsIfIncomplete = */ true,
@@ -564,7 +565,7 @@ func TestUploader(t *testing.T) {
 				).Return(object.UploadObjectMissing[any]{}, nil),
 				baseUploader.EXPECT().UploadObject(
 					gomock.Any(),
-					object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+					util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 					/* contents = */ nil,
 					[]any{
 						"Lease",
@@ -584,7 +585,7 @@ func TestUploader(t *testing.T) {
 			}()
 			result, err := uploader.UploadObject(
 				ctx,
-				object.NewInstanceName("hello/world").WithLocalReference(contents.GetLocalReference()),
+				util.Must(object.NewInstanceName("hello/world")).WithLocalReference(contents.GetLocalReference()),
 				/* contents = */ nil,
 				/* childrenLeases = */ nil,
 				/* wantContentsIfIncomplete = */ true,

--- a/pkg/storage/object/namespace.go
+++ b/pkg/storage/object/namespace.go
@@ -3,6 +3,8 @@ package object
 import (
 	"bonanza.build/pkg/proto/storage/object"
 
+	"github.com/buildbarn/bb-storage/pkg/util"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -23,12 +25,16 @@ func NewNamespace(namespaceMessage *object.Namespace) (Namespace, error) {
 	if namespaceMessage == nil {
 		return Namespace{}, status.Error(codes.InvalidArgument, "No message provided")
 	}
+	instanceName, err := NewInstanceName(namespaceMessage.InstanceName)
+	if err != nil {
+		return Namespace{}, util.StatusWrapf(err, "Invalid instance name %#v", namespaceMessage.InstanceName)
+	}
 	referenceFormat, err := NewReferenceFormat(namespaceMessage.ReferenceFormat)
 	if err != nil {
-		return Namespace{}, err
+		return Namespace{}, util.StatusWrap(err, "Invalid reference format")
 	}
 	return Namespace{
-		InstanceName:    NewInstanceName(namespaceMessage.InstanceName),
+		InstanceName:    instanceName,
 		ReferenceFormat: referenceFormat,
 	}, nil
 }

--- a/pkg/storage/tag/grpc/updater_test.go
+++ b/pkg/storage/tag/grpc/updater_test.go
@@ -12,6 +12,7 @@ import (
 	"bonanza.build/pkg/storage/tag/grpc"
 
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -92,7 +93,7 @@ func TestUpdater(t *testing.T) {
 			updater.UpdateTag(
 				ctx,
 				object.Namespace{
-					InstanceName:    object.NewInstanceName("hello/world"),
+					InstanceName:    util.Must(object.NewInstanceName("hello/world")),
 					ReferenceFormat: object.SHA256V1ReferenceFormat,
 				},
 				tag.Key{
@@ -190,7 +191,7 @@ func TestUpdater(t *testing.T) {
 		require.NoError(t, updater.UpdateTag(
 			ctx,
 			object.Namespace{
-				InstanceName:    object.NewInstanceName("hello/world"),
+				InstanceName:    util.Must(object.NewInstanceName("hello/world")),
 				ReferenceFormat: object.SHA256V1ReferenceFormat,
 			},
 			tag.Key{


### PR DESCRIPTION
Up to this point we didn't attempt to add any structure to instance names, for the reason that REv2's format has some warts, like requiring us to keep certain keywords reserved. Let's come up with a more sensible format. While there, fix the issue that using the empty instance name would result in incorrect bonanza_browser URLs.

Fixes: #26
Fixes: #27